### PR TITLE
deletes the get_thumbnail REST API call

### DIFF
--- a/framework/modelhubapi/restapi.py
+++ b/framework/modelhubapi/restapi.py
@@ -69,7 +69,8 @@ class ModelHubRESTAPI:
 
     def _thumbnail(self, thumbnail_name):
         """
-        Routing function for the thumbnail that exists in contrib_src.
+        Routing function for the thumbnail that exists in contrib_src. The
+        thumbnail must be named "thumbnail.jpg".
         """
         return send_from_directory(self.contrib_src_dir + "/model/", thumbnail_name)
 
@@ -117,7 +118,7 @@ class ModelHubRESTAPI:
         try:
             model_name = self.api.get_config()["meta"]["name"].lower()
             archive_name = os.path.join(self.working_folder, model_name + "_model")
-            shutil.make_archive(archive_name, "zip", self.contrib_src_dir, "model")            
+            shutil.make_archive(archive_name, "zip", self.contrib_src_dir, "model")
             return send_file(archive_name + ".zip", as_attachment= True)
         except Exception as e:
             return self._jsonify({'error': str(e)})
@@ -135,25 +136,6 @@ class ModelHubRESTAPI:
             samples = [ url + sample_name
                         for sample_name in self.api.get_samples()["files"]]
             return jsonify(samples)
-        except Exception as e:
-            return self._jsonify({'error': str(e)})
-
-    def get_thumbnail(self):
-        """
-        The get_thumbnail HTTP method returns a url to the model thumbnail.
-        The thumbnail file must be named "thumbnail", and could either be a jpg
-        or png.
-        """
-        try:
-            url = re.sub('\get_thumbnail$', '', request.url) + "thumbnail/"
-            path = self.contrib_src_dir + "/model/"
-            if os.path.isfile(path + "thumbnail.jpg"):
-                thumbnail = "thumbnail.jpg"
-            elif os.path.isfile(path + "thumbnail.png"):
-                thumbnail = "thumbnail.png"
-            else:
-                return self._jsonify({'error': 'Thumbnail not found'})
-            return jsonify(url + thumbnail)
         except Exception as e:
             return self._jsonify({'error': str(e)})
 

--- a/framework/modelhubapi/restapi.py
+++ b/framework/modelhubapi/restapi.py
@@ -33,8 +33,6 @@ class ModelHubRESTAPI:
                               self.get_model_files)
         self.app.add_url_rule('/api/get_samples', 'get_samples',
                               self.get_samples)
-        self.app.add_url_rule('/api/get_thumbnail', 'get_thumbnail',
-                              self.get_thumbnail)
         self.app.add_url_rule('/api/predict', 'predict',
                               self.predict, methods= ['GET', 'POST'])
 

--- a/framework/modelhubapi/webservice.py
+++ b/framework/modelhubapi/webservice.py
@@ -31,17 +31,3 @@ def _startNetron():
 def _startWebservice(model, contribSrcDir):
     restApi = ModelHubRESTAPI(model, contribSrcDir)
     restApi.start()
-
-
-
-# tests for REST API (through command line - I am mapping 80 to 4000)
-# curl -i http://localhost:4000/api/v1.0/get_config
-# curl -i http://localhost:4000/api/v1.0/get_legal
-# curl -i http://localhost:4000/api/v1.0/get_model_io
-# curl -i http://localhost:4000/api/v1.0/get_model_files
-# curl -i http://localhost:4000/api/v1.0/get_samples
-# curl -i http://localhost:4000/api/v1.0/get_thumbnail
-# these are testing on the same image, one through URL and the other through an upload. We can assert the the output from both is identical
-# curl -i http://localhost:4000/api/v1.0/predict?fileurl=https://github.com/modelhub-ai/modelhub/raw/master/squeezenet/contrib_src/sample_data/trump.jpg
-# curl -i -X POST -F file=@/home/ahmed/Dropbox/DFCI/14_zoo/modelhub/squeezenet/contrib_src/sample_data/trump.jpg "http://localhost:4000/api/v1.0/predict"
-


### PR DESCRIPTION
@michaelschwier Instead of making a call to get a single url, i removed the call. Now, the thumbnail has to be "thumbnail.jpg" which is something we can easily control in the contrib process. This will affect your tests so I will let you merge.